### PR TITLE
Create staging invoices item model

### DIFF
--- a/models/invoices_staging/sources.yml
+++ b/models/invoices_staging/sources.yml
@@ -1,8 +1,7 @@
 version: 2
 
 sources:
-  - name: invoices
-    database: ae-challenge-project  
+  - name: invoices  
     tables:
       - name: invoice_raw
       - name: invoice_item__raw

--- a/models/invoices_staging/stg_invoice_items.sql
+++ b/models/invoices_staging/stg_invoice_items.sql
@@ -1,0 +1,15 @@
+WITH base AS (
+    SELECT *
+    FROM {{ source('invoices', 'invoice_item__raw') }}
+)
+SELECT
+    invoice_id,
+    id,
+    type,
+    period_start AS period_start_at,
+    period_end AS period_end_at,
+    amount,
+    currency,
+    _synced AS synced_at
+FROM
+    base

--- a/models/invoices_staging/stg_invoice_items.yml
+++ b/models/invoices_staging/stg_invoice_items.yml
@@ -1,0 +1,30 @@
+version: 2
+
+models:
+  - name: stg_invoice_items
+    description: This model contains data on the invoice line item level along with amount, currency, and period start/end of each item
+
+    columns:
+      - name: invoice_id
+        description: Unique invoice ID
+
+      - name: id
+        description: ID associated with the invoice
+
+      - name: type
+        description: The type of the invoice item
+
+      - name: period_start_at
+        description: The invoice item period start timestamp
+
+      - name: period_end_at
+        description: The invoice item period end timestamp
+
+      - name: amount
+        description: The monetary amount of the invoice item
+
+      - name: currency
+        description: The currency of the amount
+
+      - name: synced_at
+        description: Timestamp of when the data was last updated


### PR DESCRIPTION
Two changes in this PR:
- Removing the "database" keyword:value from the `sources.yml` file to resolve a bug with dbt reading permissions
- Creating the staging model for invoice_items